### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/EllingtonWilloughby/ellingtonwilloughby/security/code-scanning/1](https://github.com/EllingtonWilloughby/ellingtonwilloughby/security/code-scanning/1)

To fix the problem, add an explicit `permissions` block at the root of the workflow (above the `jobs:` key) in `.github/workflows/nodejs.yml`. The minimal required permissions for CI build-only workflows are typically `contents: read`, since the workflow only checks out code and runs builds/tests. This ensures the GITHUB_TOKEN is only given read access. No extra methods or imports are needed—just insert the correct YAML element at the specified location.

**Specifically:**  
- Insert a block:
  ```yaml
  permissions:
    contents: read
  ```
- Place it after the workflow `name:` (line 1), before `on:` (line 3), or after `on:` (line 8), but always before `jobs:` (line 9).
- No other code modifications are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
